### PR TITLE
Fix issue #57

### DIFF
--- a/data-structure-visualizer.pro
+++ b/data-structure-visualizer.pro
@@ -13,6 +13,7 @@ HEADERS = includes/renderer.hpp \
     includes/insertdialog.hpp \
     includes/linkedlistitem.hpp \
     includes/lineitem.hpp \
+    includes/arrowlineitem.hpp \
     includes/linkedlisthandler.hpp \
     includes/doublelinkedlisthandler.hpp \
     includes/arrayhandler.hpp \
@@ -44,6 +45,7 @@ SOURCES += src/main.cpp \
     src/insertdialog.cpp \
     src/linkedlistitem.cpp \
     src/lineitem.cpp \
+    src/arrowlineitem.cpp \
     src/linkedlisthandler.cpp \
     src/doublelinkedlisthandler.cpp \
     src/arrayhandler.cpp \

--- a/includes/arrayhandler.hpp
+++ b/includes/arrayhandler.hpp
@@ -1,7 +1,12 @@
 #ifndef ARRAYHANDLER_H_
 #define ARRAYHANDLER_H_
 
+#include "lineitem.hpp"
+
 #include <memory>
+
+
+class QGraphicsLineItem;
 
 class ArrayHandler {
 
@@ -44,6 +49,19 @@ public:
      * @return int
      */
     int getData(const std::size_t index) const & noexcept;
+
+    /**
+     * @brief get the graphical connector of two consecutive items of the array
+     *
+     * @param firstItem garphical item of the array
+     * @param secondItem garphical item of the array right after firstItem
+     * 
+     * @returns LineItem*
+     */
+    static LineItem* getConnectorFromItems(
+        const QGraphicsItem* const firstItem,
+        const QGraphicsItem* const secondItem
+    );
 
 private:
 

--- a/includes/arrowlineitem.hpp
+++ b/includes/arrowlineitem.hpp
@@ -1,0 +1,114 @@
+#ifndef ARROWLINEITEM_H_
+#define ARROWLINEITEM_H_
+
+#include <QGraphicsLineItem>
+
+#include <memory>
+
+
+class ArrowLineItem : public QGraphicsLineItem
+{
+public:
+    /**
+     * @brief enum representing the integer type of the item. It should
+     * declare a Type value. UserType is the lowest permitted type value for
+     * custom items (subclasses of QGraphicsItem or any of the standard items).
+     * This value is used in conjunction with a reimplementation of
+     * QGraphicsItem::type() and declaring a Type enum value.
+     */
+    enum { Type = UserType + 1 };
+
+    /**
+     * @brief line item constructor
+     *
+     * @param startItem the item at the left side of the line
+     * @param endItem the item at the right side of the line
+     * @param widget pointer to the parent widget of the line item
+     */
+    ArrowLineItem(
+        const QGraphicsItem* startItem,
+        const QGraphicsItem* endItem,
+        QGraphicsItem* parent = 0
+    );
+
+    /**
+     * @brief getter of the integer version of the type of the line item.
+     * 
+     * Used by Qt
+     * 
+     * @return int 
+     */
+    int type() const override;
+
+    /**
+     * @brief Qt method that gives the outer bounds of the line as a rectangle
+     * 
+     * @return QRectF 
+     */
+    QRectF boundingRect() const override;
+
+    /**
+     * @brief Qt method that defines the shape of the line as a QPainterPath
+     * 
+     * This method adds the two extra arrows to the basic line shape
+     * 
+     * @return QPainterPath 
+     */
+    QPainterPath shape() const override;
+
+    /**
+     * @brief update the color of the line
+     * 
+     * @param color color of the line
+     */
+    void setColor(const QColor &color);
+
+    /**
+     * @brief make appear or disappear the start item arrow head
+     *
+     * @param enabled boolean to enable or disable a start arrow head
+     */
+    void enableStartArrowHead(const bool &enabled);
+
+    /**
+    * @brief start QGraphicsItem item the line links
+    *
+    * @return QGraphicsItem *
+    */
+    const QGraphicsItem* startItem() const;
+
+    /**
+    * @brief end QGraphicsItem item the line links
+    *
+    * @return QGraphicsItem *
+    */
+    const QGraphicsItem* endItem() const;
+
+    /**
+     * @brief update the line position 
+     * 
+     * New position is set considering the current position of the two items to
+     * link (m_startItem & m_endItem)
+     */
+    void updatePosition();
+
+protected:
+    /**
+     * @brief Qt method that paints the contents of the line item.
+     * 
+     * @param painter pointer to the Qt painter of the line item 
+     * @param option pointer to the Qt style options of the line item 
+     * @param widget pointer to the parent widget of the line item 
+     */
+    void paint(
+        QPainter* painter,
+        const QStyleOptionGraphicsItem* option,
+        QWidget* widget = 0
+    ) override;
+
+private:
+    struct Impl;
+    const std::unique_ptr<Impl> m_impl;
+};
+
+#endif

--- a/includes/doublelinkedlisthandler.hpp
+++ b/includes/doublelinkedlisthandler.hpp
@@ -1,6 +1,8 @@
 #ifndef DOUBLELINKEDLISTHANDLER_H_
 #define DOUBLELINKEDLISTHANDLER_H_
 
+#include "arrowlineitem.hpp"
+
 #include <memory>
 
 class DoubleLinkedListHandler
@@ -72,6 +74,18 @@ public:
      */
     unsigned int getData(const unsigned int& index) const & noexcept;
 
+    /**
+     * @brief get the graphical connector of two consecutive items of the list
+     * 
+     * @param firstItem garphical item of the list
+     * @param secondItem garphical item of the list right after firstItem
+     * 
+     * @return ArrowLineItem*
+     */
+    static ArrowLineItem* getConnectorFromItems(
+        const QGraphicsItem* const firstItem,
+        const QGraphicsItem* const secondItem
+    );
 private:
 
     class Impl;

--- a/includes/hashmaphandler.hpp
+++ b/includes/hashmaphandler.hpp
@@ -1,6 +1,8 @@
 #ifndef HASHMAPHANDLER_H_
 #define HASHMAPHANDLER_H_
 
+#include "arrowlineitem.hpp"
+
 #include <memory>
 
 class HashmapHandler
@@ -25,6 +27,19 @@ public:
      * @param the size of the hashmap to create
      */
     void createHashmap(const unsigned short& size); 
+
+    /**
+     * @brief get the graphical connector of two consecutive items of the map
+     *
+     * @param firstItem garphical item of the map
+     * @param secondItem garphical item of the map right after firstItem
+     * 
+     * @return ArrowLineItem*
+     */
+    static ArrowLineItem* getConnectorFromItems(
+        const QGraphicsItem* const firstItem,
+        const QGraphicsItem* const secondItem
+    );
 
 private:
 

--- a/includes/linkedlisthandler.hpp
+++ b/includes/linkedlisthandler.hpp
@@ -1,6 +1,8 @@
 #ifndef LINKEDLIST_H_
 #define LINKEDLIST_H_
 
+#include "arrowlineitem.hpp"
+
 #include <memory>
 
 struct LinkedList;
@@ -107,6 +109,18 @@ public:
      */
     unsigned int getData(const unsigned short& index) const & noexcept;
 
+    /**
+     * @brief get the graphical connector of two consecutive items of the list
+     *
+     * @param firstItem garphical item of the list
+     * @param secondItem garphical item of the list right after firstItem
+     * 
+     * @return ArrowLineItem*
+     */
+    static ArrowLineItem* getConnectorFromItems(
+        const QGraphicsItem* const firstItem,
+        const QGraphicsItem* const secondItem
+    );
 private:
 
     class Impl;

--- a/src/arrayhandler.cpp
+++ b/src/arrayhandler.cpp
@@ -26,7 +26,7 @@ ArrayHandler::~ArrayHandler() = default;
 void ArrayHandler::createArray(const std::size_t size) const & noexcept
 {
     auto& array = impl->array;
-    array = static_cast<int*>(malloc(size * sizeof(int)));
+    array = new int[size];
 
     impl->amount = size;
 

--- a/src/arrayhandler.cpp
+++ b/src/arrayhandler.cpp
@@ -64,3 +64,14 @@ int ArrayHandler::getData(const std::size_t index) const & noexcept
 {
     return impl->array[index];
 }
+
+/**
+ *
+ */
+LineItem* ArrayHandler::getConnectorFromItems(
+    const QGraphicsItem* const firstItem,
+    const QGraphicsItem* const secondItem
+)
+{
+    return new LineItem(firstItem, secondItem);
+}

--- a/src/arrowlineitem.cpp
+++ b/src/arrowlineitem.cpp
@@ -1,0 +1,193 @@
+#include "arrowlineitem.hpp"
+
+#include <qmath.h>
+#include <QPen>
+#include <QPainter>
+
+
+struct ArrowLineItem::Impl
+{
+    bool m_startArrowHeadEnabled;
+    const QGraphicsItem *m_startItem;
+    const QGraphicsItem *m_endItem;
+    QColor m_color;
+    QPolygonF m_endArrowHead;
+    QPolygonF m_startArrowHead;
+};
+
+
+ArrowLineItem::ArrowLineItem(
+    const QGraphicsItem *startItem,
+    const QGraphicsItem *endItem,
+    QGraphicsItem *parent
+)
+    : QGraphicsLineItem(parent),m_impl(std::make_unique<Impl>())
+{
+    m_impl->m_startItem = startItem;
+    m_impl->m_endItem = endItem;
+    m_impl->m_color = Qt::black;
+    m_impl->m_startArrowHeadEnabled = false;
+    setPen(QPen(m_impl->m_color, 2, Qt::SolidLine, Qt::RoundCap, Qt::RoundJoin));
+}
+
+/**
+ *
+ */
+void ArrowLineItem::enableStartArrowHead(const bool &enabled)
+{
+    m_impl->m_startArrowHeadEnabled = enabled;
+}
+
+/**
+ *
+ */
+void ArrowLineItem::setColor(const QColor &color)
+{
+    m_impl->m_color = color;
+}
+
+/**
+ *
+ */
+const QGraphicsItem* ArrowLineItem::startItem() const
+{
+    return m_impl->m_startItem;
+}
+
+/**
+ *
+ */
+const QGraphicsItem* ArrowLineItem::endItem() const
+{
+    return m_impl->m_endItem;
+}
+
+/**
+ *
+ */
+int ArrowLineItem::type() const
+{
+    return Type;
+}
+
+/**
+ *
+ */
+QRectF ArrowLineItem::boundingRect() const
+{
+    qreal extra = (pen().width() + 20) / 2.0;
+
+    return QRectF(
+                line().p1(),
+                QSizeF(
+                    line().p2().x() - line().p1().x(),
+                    line().p2().y() - line().p1().y()
+                )
+            )
+            .normalized()
+            .adjusted(-extra, -extra, extra, extra);
+}
+
+/**
+ *
+ */
+QPainterPath ArrowLineItem::shape() const
+{
+    QPainterPath path = QGraphicsLineItem::shape();
+    path.addPolygon(m_impl->m_startArrowHead);
+    path.addPolygon(m_impl->m_endArrowHead);
+    return path;
+}
+
+/**
+ *
+ */
+void ArrowLineItem::updatePosition()
+{
+    QLineF line(
+        mapFromItem(m_impl->m_startItem, 0, 0),
+        mapFromItem(m_impl->m_endItem, 0, 0)
+    );
+    setLine(line);
+}
+
+/**
+ *
+ */
+void ArrowLineItem::paint(
+    QPainter* painter,
+    const QStyleOptionGraphicsItem*,
+    QWidget*
+)
+{
+    if (m_impl->m_startItem->collidesWithItem(m_impl->m_endItem))
+    {
+        return;
+    }
+
+    QPen thisPen = pen();
+    qreal arrowSize = 20;
+    double arrowAngle(0);
+    const QRectF startItemBounds = m_impl->m_startItem->boundingRect();
+
+    thisPen.setColor(m_impl->m_color);
+    painter->setPen(thisPen);
+    painter->setBrush(m_impl->m_color);
+    setLine(
+        m_impl->m_startItem->x() + startItemBounds.width(),
+        m_impl->m_startItem->y() + startItemBounds.height(),
+        m_impl->m_endItem->x(),
+        m_impl->m_endItem->y()
+    );
+
+    // Draw the line with no arrow
+    painter->drawLine(line());
+
+    arrowAngle = std::atan2(line().dy(), -line().dx());
+    QPointF endArrowHeadLeftPoint = (
+        line().p2() +
+        QPointF(
+            sin(arrowAngle + M_PI / 3) * arrowSize,
+            cos(arrowAngle + M_PI / 3) * arrowSize
+        )
+    );
+    QPointF endArrowHeadRightPoint = (
+        line().p2() +
+        QPointF(
+            sin(arrowAngle + M_PI - M_PI / 3) * arrowSize,
+            cos(arrowAngle + M_PI - M_PI / 3) * arrowSize
+        )
+    );
+
+    m_impl->m_endArrowHead.clear();
+    m_impl->m_endArrowHead << line().p2() << endArrowHeadLeftPoint 
+                                  << endArrowHeadRightPoint;
+
+    // Draw the end arrow (from left to right)
+    painter->drawPolygon(m_impl->m_endArrowHead);
+
+    if(m_impl->m_startArrowHeadEnabled)
+    {
+        arrowAngle = std::atan2(-line().dy(), line().dx());
+        QPointF startArrowHeadLeftPoint = (
+            line().p1() +
+            QPointF(
+                sin(arrowAngle + M_PI / 3) * arrowSize,
+                cos(arrowAngle + M_PI / 3) * arrowSize
+            )
+        );
+        QPointF startArrowHeadRightPoint = (
+            line().p1() +
+            QPointF(
+                sin(arrowAngle + M_PI - M_PI / 3) * arrowSize,
+                cos(arrowAngle + M_PI - M_PI / 3) * arrowSize
+            )
+        );
+        m_impl->m_startArrowHead.clear();
+        m_impl->m_startArrowHead << line().p1() << startArrowHeadLeftPoint
+                                    << startArrowHeadRightPoint;
+
+        // Draw the start arrow (from right to left)
+        painter->drawPolygon(m_impl->m_startArrowHead);
+    }
+}

--- a/src/doublelinkedlisthandler.cpp
+++ b/src/doublelinkedlisthandler.cpp
@@ -95,3 +95,16 @@ unsigned int DoubleLinkedListHandler::getData(
         index
     );
 }
+
+/**
+ *
+ */
+ArrowLineItem* DoubleLinkedListHandler::getConnectorFromItems(
+    const QGraphicsItem* const firstItem,
+    const QGraphicsItem* const secondItem
+)
+{
+    ArrowLineItem* connector = new ArrowLineItem(firstItem, secondItem);
+    connector->enableStartArrowHead(true);
+    return connector;
+}

--- a/src/hashmaphandler.cpp
+++ b/src/hashmaphandler.cpp
@@ -30,3 +30,14 @@ void HashmapHandler::createHashmap(const unsigned short& size)
 {
     impl->hashmap = createHM(size);
 }
+
+/**
+ *
+ */
+ArrowLineItem* HashmapHandler::getConnectorFromItems(
+    const QGraphicsItem* const firstItem,
+    const QGraphicsItem* const secondItem
+)
+{
+    return new ArrowLineItem(firstItem, secondItem);
+}

--- a/src/linkedlisthandler.cpp
+++ b/src/linkedlisthandler.cpp
@@ -1,8 +1,7 @@
 #include "linkedlisthandler.hpp"
 #include "linkedlistitem.hpp"
-#include "lineitem.hpp"
-
 #include "linked_list.h"
+#include "arrowlineitem.hpp"
 
 #include <QPointer>
 #include <QGraphicsScene>
@@ -195,4 +194,15 @@ unsigned int LinkedListHandler::getData(
         &impl->list,
         index
     );
+}
+
+/**
+ *
+ */
+ArrowLineItem* LinkedListHandler::getConnectorFromItems(
+    const QGraphicsItem* const firstItem,
+    const QGraphicsItem* const secondItem
+)
+{
+    return  new ArrowLineItem(firstItem, secondItem);
 }

--- a/src/renderer.cpp
+++ b/src/renderer.cpp
@@ -1,12 +1,12 @@
 #include "renderer.hpp"
 #include "linkedlistitem.hpp"
-#include "lineitem.hpp"
 #include "linkedlisthandler.hpp"
 #include "doublelinkedlisthandler.hpp"
 #include "arrayhandler.hpp"
 
 #include <QGraphicsScene>
 #include <QPointer>
+#include <QGraphicsLineItem>
 
 /**
  *
@@ -46,12 +46,11 @@ void render(
 
         if (not lastItem.isNull())
         {
-            LineItem* line = new LineItem(
+            QGraphicsLineItem* itemConnector = structure->getConnectorFromItems(
                 lastItem,
                 item
             );
-
-            scene->addItem(line);
+            scene->addItem(itemConnector);
         }
 
         scene->addItem(item);


### PR DESCRIPTION
### WHAT
- Fix issue #57 (Implement an arrow line between items of link-based structures)
- Use `new int[ length  ]` for dynamic allocation instead of `malloc( sizeof(int) * length)`

![double-linked-list-with-arrows](https://user-images.githubusercontent.com/13803272/37136652-c6ed69ec-22a2-11e8-93ac-90a885b2f5f8.png)
